### PR TITLE
Update action node version to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,6 @@ inputs:
     required: false
     default: 'latest'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/main/index.js'
   post: 'dist/cleanup/index.js'


### PR DESCRIPTION
Bumping node version to 16 as 12 is being deprecated.
By the looks of the `package.json` it shouldn't be a problem as the installed node types is 18.

Reference:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
